### PR TITLE
Wrap macro import in createMacro

### DIFF
--- a/greeting.macro.js
+++ b/greeting.macro.js
@@ -1,7 +1,8 @@
 // ast-pretty-print is really handy :)
 const printAST = require('ast-pretty-print')
+const {createMacro} = require('babel-macros')
 
-module.exports = greetingMacro
+module.exports = createMacro(greetingMacro)
 
 function greetingMacro({references, babel}) {
   const {default: hello = [], goodbye = []} = references

--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
   "devDependencies": {
     "ast-pretty-print": "^2.0.0",
     "babel-cli": "^6.24.1",
-    "babel-macros": "^0.5.2"
+    "babel-macros": "^1.1.1"
   }
 }


### PR DESCRIPTION
The macro imported from "./x.macro" must be wrapped in "createMacro" which you can get from "babel-macros". Please refer to the documentation to see how to do this properly: https://github.com/kentcdodds/babel-macros/blob/master/other/docs/author.md#writing-a-macro