### PR TITLE
Fix up jest error

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
     "babel-plugin-macros": "^2.0.0",
     "babel-plugin-tester": "^5.0.0",
     "jest": "^22.1.4"
+  },
+  "jest": {
+    "testURL": "http://localhost"
   }
 }


### PR DESCRIPTION
Was getting `SecurityError: localStorage is not available for opaque origins`. Fixed by adding this config.

Trying to use this repo to learn how to write my own macros and found this error. 